### PR TITLE
Firefox friendly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const deepDiff = require('deep-diff')
 const padRight = require('pad-right')
 const padLeft = require('pad-left')
+const browser = require('detect-browser')
 
 module.exports = chooLog
 
@@ -159,14 +160,20 @@ function renderActionType (msg) {
 // toHtml + chalk
 // (str, str, [str, ...str]) -> [str, str]
 function colorify (color, line, prev) {
-  if (prev) {
-    if (!prev[0]) prev[0] = ''
-    prev[0] = prev[0] += ' %c' + line
-    prev.push('color: ' + colors[color])
-    return prev
+  var newLine = '%c' + line
+  var newStyle = 'color: ' + colors[color] + ';'
+
+  if (!prev) return [ newLine, newStyle ]
+
+  if (!prev[0]) prev[0] = ''
+  prev[0] += ' ' + newLine
+
+  if (browser.name === 'firefox') {
+    prev[1] = prev[1] + ' ' + newStyle
   } else {
-    return [ '%c' + line, 'color: ' + colors[color] ]
+    prev.push(newStyle)
   }
+  return prev
 }
 
 // render the time

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function chooLog () {
     colorify('default', '->', line)
     colorify('default', "'" + name + "'", line)
 
-    if (console.groupCollapsed) {
+    if (groupCollapseSupported()) {
       logGroup(line)
       logInner(name, data)
       console.groupEnd()
@@ -71,7 +71,7 @@ function chooLog () {
     colorify('red', renderType('error') + ' ', line)
     colorify('default', err.message + ' ', line)
 
-    if (console.groupCollapsed) {
+    if (groupCollapseSupported()) {
       logGroup(line)
       logInner(err)
       console.groupEnd()
@@ -106,7 +106,7 @@ function chooLog () {
     colorify(hasWarn ? 'yellow' : 'gray', renderType('state') + ' ', line)
     colorify('default', (hasWarn ? '' : diff.length + ' ') + inlineText, line)
 
-    if (console.groupCollapsed) {
+    if (groupCollapseSupported()) {
       logGroup(line)
       logInner(prev, state)
       console.groupEnd()
@@ -163,13 +163,17 @@ function colorify (color, line, prev) {
   var newLine = '%c' + line
   var newStyle = 'color: ' + colors[color] + ';'
 
-  if (!prev) return [ newLine, newStyle ]
+  if (!prev) {
+    prev = [ newLine, newStyle ]
+    return prev
+  }
 
   if (!prev[0]) prev[0] = ''
   prev[0] += ' ' + newLine
 
+  if (!prev[1]) prev[1] = ''
   if (browser.name === 'firefox') {
-    prev[1] = prev[1] + ' ' + newStyle
+    prev[1] += ' ' + newStyle
   } else {
     prev.push(newStyle)
   }
@@ -183,3 +187,8 @@ function renderTime (startTime) {
   var msg = '[' + padLeft(offset, 4, '0') + ']'
   return msg
 }
+
+function groupCollapseSupported () {
+  return console.groupCollapsed && browser.name !== 'firefox'
+}
+

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "deep-diff": "^0.3.4",
+    "detect-browser": "^1.5.0",
     "pad-left": "^2.1.0",
     "pad-right": "^0.2.2"
   },


### PR DESCRIPTION
Choo-log is currently pretty broken in firefox ): 

I've spent some time trying to get groupCollapse logging to work in firefox _**with color**_ but it really doesn't want to play. Everything I've tried sees the log just spitting out raw %c color: #272727 junk.

This pull request: 
- adds `ditect-browser`
- changes `line` building to match a format firefox will render
- disables groupCollapse logging for ff 
