### PR TITLE
chore(package): update nanologger to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "nanologger": "^1.2.0",
+    "nanologger": "^1.3.0",
     "on-idle": "^3.0.2",
     "on-performance": "^1.0.0"
   },


### PR DESCRIPTION
i don't think greenkeeper got triggered for nanologger, here is an update for 1.3.0