### PR TITLE
Add compatibility with es6 'export default' syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var assert = require('assert')
 var ChooInstrument = require('./lib/instrument')
 
 module.exports = logger
+module.exports["default"] = logger
 
 function logger (opts) {
   opts = opts || {}


### PR DESCRIPTION
I used choo-log with TypeScript, and I noticed that currently this module is not compatible with ES6 import syntax. This PR makes it.