### PR TITLE
fix nodejs versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 node_js:
-- "0.12"
-- "4"
+- '6'
+- '7'
+- '8'
 sudo: false
 language: node_js
 script: "npm run test:cov"


### PR DESCRIPTION
It's about time to ignore `0.12`.:P

```
/home/travis/build/choojs/choo-log/node_modules/dependency-check/node_modules/read-package-json/node_modules/json-parse-better-errors/index.js:9
    const syntaxErr = e.message.match(/^Unexpected token.*position\s+(\d+)/i)
    ^^^^^
```